### PR TITLE
feat(lib): return unsubscribe function from subscription

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ interface Observer<T> {
 }
 
 interface Observable<T> {
-  subscribe: (observer: Observer<T>) => void;
+  subscribe: (observer: Observer<T>) => () => void;
   unsubscribe?: () => void;
 }
 
@@ -13,10 +13,13 @@ interface Observable<T> {
  * @param {function} subscribe
  */
 export default class Stream<T> implements Observable<T> {
-  subscribe: (o: Observer<T>) => void;
+  subscribe: (o: Observer<T>) => () => void;
   unsubscribe?: () => void;
 
-  constructor(subscribe: (o: Observer<T>) => void, unsubscribe?: () => void) {
+  constructor(
+    subscribe: (o: Observer<T>) => () => void,
+    unsubscribe?: () => void,
+  ) {
     this.subscribe = subscribe;
     this.unsubscribe = unsubscribe;
   }
@@ -61,6 +64,8 @@ export default class Stream<T> implements Observable<T> {
         observer.complete();
         target.removeEventListener(type, observer.next);
       };
+
+      return _streamFromEvent.unsubscribe;
     });
 
     return _streamFromEvent;
@@ -82,6 +87,8 @@ export default class Stream<T> implements Observable<T> {
         observer.complete();
         clearTimeout(_timer);
       };
+
+      return _streamFromTimer.unsubscribe;
     });
 
     return _streamFromTimer;
@@ -103,6 +110,8 @@ export default class Stream<T> implements Observable<T> {
         observer.complete();
         clearInterval(_timer);
       };
+
+      return _streamFromInterval.unsubscribe;
     });
 
     return _streamFromInterval;
@@ -128,6 +137,8 @@ function _map<T, U>(fn: (t: T) => U): (s: Stream<T>) => Stream<U> {
           stream.unsubscribe();
         }
       };
+
+      return _mappedStream.unsubscribe;
     });
 
     return _mappedStream;
@@ -155,6 +166,8 @@ function _filter<T>(fn: (t: T) => boolean): (s: Stream<T>) => Stream<T> {
           stream.unsubscribe();
         }
       };
+
+      return _filteredStream.unsubscribe;
     });
 
     return _filteredStream;
@@ -191,6 +204,8 @@ function debounceTime<T>(ms: number): (s: Stream<T>) => Stream<T> {
           stream.unsubscribe();
         }
       };
+
+      return _debouncedStream.unsubscribe;
     });
 
     return _debouncedStream;
@@ -249,6 +264,8 @@ function _withLatestFrom<T, U>(
           streamA.unsubscribe();
         }
       };
+
+      return _tupleStream.unsubscribe;
     });
 
     return _tupleStream;
@@ -282,6 +299,8 @@ function _switchMap<T, U>(
         outerStream?.unsubscribe?.();
         observer.complete();
       };
+
+      return _switchMapStream.unsubscribe;
     });
 
     return _switchMapStream;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rex",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rex",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rex",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Everything is streams.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,12 +5,9 @@
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "bundler",
     "module": "ESNext",
-    "strict": true
+    "strict": true,
+    "target": "ES2022"
   },
-  "include": [
-    "*.ts"
-  ],
-  "exclude": [
-    "/dist"
-  ]
+  "include": ["*.ts"],
+  "exclude": ["/dist"]
 }


### PR DESCRIPTION
## feat(lib): return unsubscribe function from subscription

Returns `unsubscribe` handler from subscription. This allows unsubscribing from source stream after subscribing without holding on a separate stream reference:

#### Before

```typescript
const $halfSecStream = Stream.fromInterval(500);
const $mixedTimerStream =
  Stream.fromInterval(1000).withLatestFrom($halfSecStream);

$mixedTimerStream.subscribe({
  next: ([halfSecTick, oneSecTick]) => {
    console.log(halfSecTick, oneSecTick);
    if (halfSecTick >= 5) $mixedTimerStream.unsubscribe?.();
  },
  complete: () => {
    console.log('stream concluded');
  },
});
```

#### After

```typescript
const $halfSecStream = Stream.fromInterval(500);
const mixedTimerUnsub =
  Stream.fromInterval(1000)
  .withLatestFrom($halfSecStream)
  .subscribe({
    next: ([halfSecTick, oneSecTick]) => {
      console.log(halfSecTick, oneSecTick);
      if (halfSecTick >= 5) mixedTimerStream();
    },
    complete: () => {
      console.log('stream concluded');
    },
});
```